### PR TITLE
添加AddDAOffset函数

### DIFF
--- a/qos/+qes/+hwdriver/+sync/+ustcadda_backend/USTCDAC.m
+++ b/qos/+qes/+hwdriver/+sync/+ustcadda_backend/USTCDAC.m
@@ -24,6 +24,7 @@ classdef USTCDAC < handle
         da_range = 0.8;         %æœ?¤§ç�?µåŽ‹ï¼Œæœªä½¿ç�?¨
         gain = zeros(1,4);      %é€š�?“å¢žç�?Š
         offset = zeros(1,4);    %é€š�?“�??ç½®
+        mixer_offset = zeros(1,4); % use to fix the offset of mixer
         offsetcorr  = zeros(1,4); % å…³é�?­DACç�?µåŽ�?
         
         trig_sel = 0;           %è§¦å?‘æ�?é?æ�?
@@ -150,9 +151,9 @@ classdef USTCDAC < handle
             end
 
             for k = 1:obj.channel_amount
-%                 obj.SetOffset(k-1,obj.offset(k));
-                obj.SetGain(k-1,obj.gain(k));
-                obj.SetDefaultVolt(k-1,-obj.offsetcorr(k)+32767);
+%                 obj.SetOffset(k,obj.offset(k));
+                obj.SetGain(k,obj.gain(k));
+                obj.SetDefaultVolt(k,-obj.offsetcorr(k)+32767);
             end
             obj.PowerOnDAC(1,0);
             obj.PowerOnDAC(2,0);
@@ -293,7 +294,7 @@ classdef USTCDAC < handle
         function SetGain(obj,channel,data)
              obj.AutoOpen();
              map = [2,3,0,1];       %æœ‰bugï¼Œéœ€è�?å?šä¸?¬¡æ˜ å°�?
-             channel = map(channel+1);
+             channel = map(channel);
              ret = calllib(obj.driver,'WriteInstruction',obj.id,uint32(hex2dec('00000702')),uint32(channel),uint32(data));
              if(ret == -1)
                  error('USTCDAC:WriteGain','WriteGain failed.');
@@ -303,7 +304,7 @@ classdef USTCDAC < handle
         function SetOffset(obj,channel,data)
             obj.AutoOpen();
             map = [6,7,4,5];       %æœ‰bugï¼Œéœ€è�?å?šä¸?¬¡æ˜ å°�?
-            channel = map(channel+1);
+            channel = map(channel);
             ret = calllib(obj.driver,'WriteInstruction',obj.id,uint32(hex2dec('00000702')),uint32(channel),uint32(data));
             if(ret == -1)
                  error('USTCDAC:WriteOffset','WriteOffset failed.');
@@ -312,7 +313,7 @@ classdef USTCDAC < handle
         
         function SetDefaultVolt(obj,channel,volt)
             obj.AutoOpen();
-
+            channel = channel-1;
             ret = calllib(obj.driver,'WriteInstruction',obj.id,uint32(hex2dec('00001B05')),uint32(channel),uint32(volt));
             if(ret == -1)
                  error('USTCDAC:WriteOffset','WriteOffset failed.');
@@ -331,6 +332,7 @@ classdef USTCDAC < handle
         function WriteWave(obj,ch,offset,wave)
             obj.AutoOpen();
             % èŒƒå›´é™?åˆ¶
+            wave = wave + obj.mixer_offset(ch) + obj.offsetcorr(ch);
             wave(wave > 65535) = 65535;
             wave(wave < 0) = 0;
             % è¡¥å¤Ÿ512bitçš„ä�?å®½æ•´æ�?°å?
@@ -385,6 +387,7 @@ classdef USTCDAC < handle
        % è¯¥å‡½æ�?°æœªä½¿ç�?¨
         function wave = ReadWave(obj,ch,offset,len)
               obj.AutoOpen();
+              ch = ch - 1;
               wave = [];
               startaddr = (ch*2)*2^18 + 2*offset;
               ret = calllib(obj.driver,'ReadMemory',obj.id,uint32(hex2dec('00000003')),uint32(startaddr),uint32(len*2));
@@ -399,6 +402,7 @@ classdef USTCDAC < handle
        % è¯¥å‡½æ�?°æœªä½¿ç�?¨
         function seq = ReadSeq(obj,ch,offset,len)
               obj.AutoOpen();
+              ch = ch - 1;
               startaddr = (ch*2+1)*2^18 + offset*8;
               ret = calllib(obj.driver,'ReadMemory',obj.id,uint32(hex2dec('00000003')),uint32(startaddr),uint32(len*8));
               if(ret == 0)
@@ -529,6 +533,11 @@ classdef USTCDAC < handle
             if(ret ~= 0)
                error('USTCDAC:SetTimeOut','Set timeout failed!');
             end
+        end
+        
+        function AddOffset(obj,ch,offset)
+            obj.mixer_offset(ch) = offset;
+            obj.SetDefaultVolt(ch,32767-obj.offsetcorr(k)-obj.mixer_offset(ch));
         end
         
         % removed by Yulin Wu, 170427

--- a/qos/+qes/+hwdriver/+sync/ustcadda_v1.m
+++ b/qos/+qes/+hwdriver/+sync/ustcadda_v1.m
@@ -478,8 +478,7 @@ classdef ustcadda_v1 < qes.hwdriver.icinterface_compatible % extends icinterface
             
             % redefined offsetCorr to be a da board specific property other
             % than a ustcadda property, Yulin Wu
-            data = uint16(data +...
-                obj.da_list(obj.da_channel_list(channel).index).da.offsetcorr(obj.da_channel_list(channel).ch)); 
+            data = uint16(data); 
             % ?��?波形
             da_struct.da.WriteWave(ch,0,data);
             % 相当于或上一个�???
@@ -548,6 +547,17 @@ classdef ustcadda_v1 < qes.hwdriver.icinterface_compatible % extends icinterface
                 name = obj.da_list(k).da.name;
                 if(strcmpi(name,da_name))
                     obj.da_list(k).da_trig_delay = point;
+                end
+            end
+        end
+        
+        function AddDAOffset(obj,ch,offset)
+            if(length(ch)==length(offset))
+                for k =1:length(ch)
+                    ch_info = obj.da_channel_list(ch(k));
+                    channel = ch_info.ch;
+                    da = obj.da_list(ch_info.index).da;
+                    da.AddOffset(channel,offset(k))
                 end
             end
         end


### PR DESCRIPTION
AddDAOffset接收一个通道数组和一个偏置数据数组，通过在默认波形输出和脉冲波形输出基础上加上固定偏置来实现IQ校准，该函数需要在SendWave函数前调用。